### PR TITLE
[Docs] Fixing broken links

### DIFF
--- a/fern/api-reference/stream-speech-websocket.mdx
+++ b/fern/api-reference/stream-speech-websocket.mdx
@@ -46,6 +46,14 @@ Send a JSON-encoded message on the WebSocket. The schema of said message should 
   "add_timestamps": false
 }
 ```
+You may also cancel outgoing requests through the websocket. This will only halt requests that have not begun generating a response yet.
+
+```json WebSocket Request
+{
+  "context_id": "happy-monkeys-fly",
+  "cancel": true,
+}
+```
 
 ## WebSocket Responses
 

--- a/fern/apis/endpoints/openapi.yml
+++ b/fern/apis/endpoints/openapi.yml
@@ -311,6 +311,7 @@ components:
               transcript:
                 title: Transcript
                 type: string
+                description: A transcript for the generation. Should not be empty and should not be only puncutation.
                 example: "Hello, world! I'm generating audio on Cartesia."
               duration:
                 title: Duration
@@ -635,6 +636,7 @@ components:
               transcript:
                 title: Transcript
                 type: string
+                description: A transcript for the generation. Should not be empty and should not be only puncutation.
                 example: "Hello, world! I'm generating audio on Cartesia."
               duration:
                 title: Duration

--- a/fern/getting-started/dev-quickstart.mdx
+++ b/fern/getting-started/dev-quickstart.mdx
@@ -19,7 +19,7 @@ Using WebSockets is ideal for:
 - **Streaming audio to other services:** Streaming audio in realtime, such as for live broadcasts or [telephony applications](/user-guides/cartesia-twilio).
 - **Input streaming:** When you don't have the transcript available upfront like when [streaming from a language model](/getting-started/dev-quickstart#input-streaming-for-conversational-applications).
 
-<Card title="Using WebSockets" icon="code" href="/api-reference/endpoints/stream-speech-websocket">
+<Card title="Using WebSockets" icon="code" href="/reference/web-socket/stream-speech/stream-speech">
     API Reference for the WebSockets endpoint.
 </Card>
 
@@ -27,12 +27,12 @@ Using WebSockets is ideal for:
 
 In many real-time use cases, you don't have your transcripts available upfront—like when you're generating them using a language model. For these cases, Sonic supports input streaming using WebSocket contexts. This allows you to stream a transcript in multiple chunks to Sonic and receive seamless speech in return.
 
-<Card title="Input Streaming with WebSockets" icon="code" href="/api-reference/endpoints/stream-speech-websocket#input-streaming-with-contexts">
+<Card title="Input Streaming with WebSockets" icon="code" href="/reference/web-socket/stream-speech/working-with-web-sockets#input-streaming-with-contexts">
     API Reference for Input Streaming and working with Contexts.
 </Card>
 
 <Note>
-Read up the Input Streaming section in the [WebSocket API Reference](/api-reference/endpoints/stream-speech-websocket#input-streaming-with-contexts) before you start building your conversational applications.
+Read up the Input Streaming section in the [WebSocket API Reference](/reference/web-socket/stream-speech/working-with-web-sockets#input-streaming-with-contexts) before you start building your conversational applications.
 </Note>
 
 For the best performance, we recommend the following usage pattern:


### PR DESCRIPTION
A few doc changes:
- Adding cancellation to the websocket documentation
- Adding a description to transcript in TTS Requests and TTS Requests (Bytes)
- Fixing broken links in dev quickstart

Checked the Preview - lgtm