### PR TITLE
Fixing broken links

### DIFF
--- a/fern/getting-started/getting-help.mdx
+++ b/fern/getting-started/getting-help.mdx
@@ -6,10 +6,10 @@ slug: getting-started/getting-help
 
 
 <CardGroup cols={2}>
-  <Card title="Discord" icon="fa-brands fa-discord" href="https://discord.com/invite/gAbbHgdyQM">
+  <Card title="Discord" icon="fa-brands fa-discord" href="https://discord.gg/cartesia">
       Join our Discord server to chat with the Cartesia team, engage with the community, and get help with your projects.
   </Card>
-  <Card title="Email" icon="envelope" href="https://discord.com/invite/gAbbHgdyQM">
+  <Card title="Email" icon="envelope" href="mailto:support@cartesia.ai">
       Email us at support@cartesia.ai to get help with your integrating Cartesia, your account, or billing.
   </Card>
 </CardGroup>

--- a/fern/getting-started/using-the-api.mdx
+++ b/fern/getting-started/using-the-api.mdx
@@ -7,7 +7,7 @@ slug: getting-started/using-the-api
 
 ## Quickstart
 
-To get started with the API, the first thing you’ll need is an API key. You can get one by logging into the playground and heading to "Console" at [play.cartesia.ai/console](https://play.cartesia.ai/console).
+To get started with the API, the first thing you’ll need is an API key. You can get one by logging into the playground and heading to "Console" at [play.cartesia.ai/keys](https://play.cartesia.ai/keys).
 
 To generate your first words, run this command in your terminal, replacing `YOUR_API_KEY`:
 
@@ -55,7 +55,7 @@ Our versioning scheme is inspired by the [Anthropic API](https://docs.anthropic.
 
 ### Use API keys to authenticate
 
-Authentication is handled using API keys. You can create a new API key from [play.cartesia.ai/console](https://play.cartesia.ai/console).
+Authentication is handled using API keys. You can create a new API key from [play.cartesia.ai/keys](https://play.cartesia.ai/keys).
 
 * For HTTP requests, authentication is handled by adding the field `X-API-Key: <your_api_key>` into the HTTP headers.
 * For WebSocket connections, authentication is handled by passing in the field `?api_key=<your_api_key>` when creating the WebSocket connection.


### PR DESCRIPTION
## Overview ##

### Getting Help ###
- Similar to https://github.com/cartesia-ai/bifrost/pull/848, the Discord link in getting help section of the docs is expired.
- A cherry on top is the support email link just links to the broken discord.

### Using the API ###
- We had 2 deprecated references to `/console` instead of `/keys`

## Testing ##

Looked at the preview docs and confirmed.