### PR TITLE
Add Voice Conversion to documentation

### DIFF
--- a/fern/apis/endpoints/openapi.yml
+++ b/fern/apis/endpoints/openapi.yml
@@ -60,7 +60,8 @@ paths:
     post:
       summary: Voice Conversion (Server-Sent Events)
       description: |-
-        Converts an audio clip to a new voice. The audio is streamed out as Server-Sent Events. To specify the voice, exactly one of `voice_id` or `voice_embedding` must be specified.
+        Converts an audio clip to a new voice. The audio is streamed out as Server-Sent Events.
+        To specify the target voice, exactly one of `voice_id` or `voice_embedding` must be given.
       x-fern-streaming: true
       parameters:
         - $ref: "#/components/parameters/Cartesia-Version"
@@ -72,6 +73,7 @@ paths:
               required:
                 - clip
                 - model_id
+                - output_format[sample_rate]
                 # We should require one of voice_id and voice_embedding. This will be easier with OpenAPI 4: https://github.com/OAI/sig-moonwalk/discussions/100
               properties:
                 clip:
@@ -87,6 +89,16 @@ paths:
                   type: string
                   description: The ID of the model to use for the conversion. For voice conversion, this must be `voice-conversion`.
                   example: voice-conversion
+                output_format[sample_rate]:
+                  title: Sample Rate
+                  type: integer
+                  description: The sample rate of the output.
+                  example: 44100
+                output_format[encoding]:
+                  title: Encoding
+                  description: The encoding of the output. This is optional, and defaults to `pcm_f32le` unless specified.
+                  type: string
+                  enum: ["pcm_s16le", "pcm_f32le", "pcm_mulaw", "pcm_alaw"]
                 voice_id:
                   type: string
                   description: The ID of the voice to convert to. 

--- a/fern/apis/endpoints/openapi.yml
+++ b/fern/apis/endpoints/openapi.yml
@@ -56,6 +56,63 @@ paths:
                   propertyName: status_code
         default:
           $ref: "#/components/responses/Error"
+  "/voice-conversion/sse":
+    post:
+      summary: Voice Conversion (Server-Sent Events)
+      description: |-
+        Converts an audio clip to a new voice. The audio is streamed out as Server-Sent Events. To specify the voice, exactly one of `voice_id` or `voice_embedding` must be specified.
+      x-fern-streaming: true
+      parameters:
+        - $ref: "#/components/parameters/Cartesia-Version"
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - clip
+                - model_id
+                # We should require one of voice_id and voice_embedding. This will be easier with OpenAPI 4: https://github.com/OAI/sig-moonwalk/discussions/100
+              properties:
+                clip:
+                  type: string
+                  format: binary
+                  description: The audio clip to convert to a new voice. Must be at most 4 MB in size.
+                context_id:
+                  type: string
+                  description: A unique identifier for the requests belonging to this context. Context id must consist of only alphanumeric characters, hyphens, and underscores.
+                  example: "happy-monkeys-fly"
+                model_id:
+                  title: Model ID
+                  type: string
+                  description: The ID of the model to use for the conversion. For voice conversion, this must be `voice-conversion`.
+                  example: voice-conversion
+                voice_id:
+                  type: string
+                  description: The ID of the voice to convert to. 
+                  example: a0e99841-438c-4a64-b679-ae501e7d6091
+                voice_embedding:
+                  type: string
+                  description: |- 
+                    A string containing an array of numbers representing the voice embedding. The array must be exactly 192 numbers long.
+                    
+                    Warning: Unlike other endpoints, for voice conversion you must pass in voice embeddings as a _string_, not an array object.
+      responses:
+        "200":
+          description: A stream of audio data.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/JSONChunkResponse"
+                  - $ref: "#/components/schemas/JSONDoneResponse"
+                  - $ref: "#/components/schemas/JSONErrorResponse"
+                discriminator:
+                  propertyName: status_code
+        default:
+          $ref: "#/components/responses/Error"
+
+
 
   "/voices":
     get:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -85,12 +85,12 @@ navigation:
             path: migration-guides/migrating-to-the-stable-api.mdx
   - tab: reference
     layout:
-      - api: WebSocket
+      - api: WebSocket (Speech)
         api-name: wss
         flattened: true
         layout:
           - stream-speech:
-              title: WebSocket
+              title: WebSocket (Speech)
               contents:
                 - WSS /tts/websocket
                 - page: Working with WebSockets
@@ -100,10 +100,16 @@ navigation:
         paginated: true
         flattened: true
         layout:
-          - section: REST
+          - section: Speech
             contents:
               - POST /tts/bytes
               - POST /tts/sse
+          - section: Voice Conversion
+            contents:
+              - POST /voice-conversion/sse
+          - section:
+          - section: Voices
+            contents:
               - POST /voices/clone/clip
               - POST /voices/mix
               - POST /voices/localize
@@ -112,4 +118,6 @@ navigation:
               - PATCH /voices/{id}
               - GET /voices/{id}
               - GET /voices
+          - section: Other
+            contents:
               - GET /

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -90,17 +90,14 @@ navigation:
         flattened: true
         layout:
           - stream-speech:
-              title: WebSocket (Speech)
-              contents:
-                - WSS /tts/websocket
-                - page: Working with WebSockets
-                  path: api-reference/stream-speech-websocket.mdx
+              - WSS /tts/websocket
+              - page: Working with WebSockets
+                path: api-reference/stream-speech-websocket.mdx
       - api: API Reference
         api-name: endpoints
-        paginated: true
         flattened: true
         layout:
-          - section: Speech
+          - section: Speech 
             contents:
               - POST /tts/bytes
               - POST /tts/sse


### PR DESCRIPTION
This PR does the following:
- splits our docs into a few sections (Speech WS, Speech POST, VC POST, Voices, Other) 
- adds usage instructions for a voice conversion POST SSE endpoint

Note: This PR should not be merged until the corresponding API endpoint updates have been made.