### PR TITLE
Temporary: clean up voice clone docs

### DIFF
--- a/fern/build-with-sonic/capabilities/clone-voices.mdx
+++ b/fern/build-with-sonic/capabilities/clone-voices.mdx
@@ -8,13 +8,23 @@ subtitle: >-
   <img src="/assets/images/clone.png" />
 </Frame>
 
-Voice cloning is available through the [playground](https://play.cartesia.ai) and the [API](/api-reference/voices/clone-from-clip).
+Voice cloning is available through the [playground](https://play.cartesia.ai) and the [API](/api-reference/voices/clone). Voice cloning has two modes: stability and similarity. High-similarity clones sound more like the source clip, but may reproduce background noise. Stability clones always sound like a studio recording, but may not sound as similar to the source clip.
 
-For the best voice clones, we recommend following these practices in the source clip:
+For the best voice clones, we recommend following these best practices:
 
-1. **Choose an appropriate transcript to speak.** You want the transcript you record to align as closely as possible with the voice you want to generate. For example, don't read a colorless transcript in a monotone voice unless you're aiming for a monotonous clone. Instead, prepare a transcript that is suited to your use case and has the right energy.
+## General best practices for voice cloning
+
+1. **Choose an appropriate script to speak.** You want your recording to align as closely as possible with the voice you want to generate. For example, don't read a colorless transcript in a monotone voice unless you're aiming for a monotonous clone. Instead, prepare a script that is suited to your use case and has the right energy.
 2. **Speak as clearly as possible and avoid background noise.** For example, when recording yourself, try to use a high-quality microphone, be in a quiet space, and so on.
-3. **Limit your recording to 10 to 20 seconds.** This is the sweet spot—a longer clip will not result in a better clone.
-4. **Set `enhance` to `true` when cloning.** This optimizes sample clip quality prior to voice cloning-—improving clone fidelity, especially for lower-quality samples. Note that this may increase overall volume and remove background noises.
-5. **Avoid long pauses in the clip.** Too many long pauses could result in the cloned voice drifting from the source clip.
-6. **Speak in the target language.** For instance, if you want the cloned voice to speak Spanish, speak Spanish in the recording. If this is not possible, you can use Cartesia's localization feature—available in the playground and in the API—to convert your clone to a different language.
+3. **Avoid long pauses in the clip.** Too many long pauses could result in the cloned voice drifting from the source clip.
+4. **Speak in the target language.** For instance, if you want the cloned voice to speak Spanish, speak Spanish in the recording. If this is not possible, you can use Cartesia's localization feature—available in the playground and in the API—to convert your clone to a different language.
+
+## Best practices for high-similarity clones
+
+1. **Limit your recording to five seconds.** This is the sweet spot for high-similarity clones. A longer clip will not result in a better clone.
+2. **Set `enhance` to `false` when cloning.** Unless your source clip has substantial background noise, any postprocessing will reduce the similarity of the clone to the source clip.
+
+## Best practices for high-stability clones
+
+1. **Limit your recording to 10 to 20 seconds.** This is the sweet spot—a longer clip will not result in a better clone.
+2. **Set `enhance` to `true` when cloning.** This optimizes sample clip quality prior to voice cloning-—improving clone fidelity, especially for lower-quality samples. Note that this may increase overall volume and remove background noises.

--- a/fern/definition/voices.yml
+++ b/fern/definition/voices.yml
@@ -219,11 +219,20 @@ service:
       path: /clone
       method: POST
       display-name: Clone Voice
+      docs: |
+        Clone a voice from an audio clip. This endpoint has two modes, stability and similarity.
+
+        Similarity mode clones are more similar to the source clip, but may reproduce background noise. For these, use an audio clip about 5 seconds long.
+
+        Stability mode clones are more stable, but may not sound as similar to the source clip. For these, use an audio clip 10-20 seconds long.
       request:
         name: CloneVoiceRequest
         body:
           properties:
-            clip: file
+            clip:
+              type: file
+              docs: |
+                The audio clip to clone. For stability mode, the clip should be 10-20 seconds long. For similarity mode, the clip should be about 5 seconds long.
             name:
               type: string
               docs: |
@@ -275,7 +284,7 @@ service:
             mode: similarity
             language: en
             transcript: "A transcript of the words spoken in the audio clip."
-            enhance: true
+            enhance: false
           response:
             body:
               id: "40248dd5-bfe9-48e2-93f7-ea3f9d5c7f72"

--- a/fern/definition/voices.yml
+++ b/fern/definition/voices.yml
@@ -285,23 +285,3 @@ service:
               description: "Copied from Cartesia docs"
               created_at: "2024-11-13T07:06:22.476564Z"
               language: en
-
-    cloneFromClip:
-      path: /clone/clip
-      method: POST
-      display-name: Clone Voice from Clip
-      docs: |
-        Clone a voice from a clip. The clip should be a 15-20 second recording of a person speaking with little to no background noise.
-
-        The endpoint will return an embedding that can either be used directly with text-to-speech endpoints or used to create a new voice.
-      request:
-        name: CloneFromClipRequest
-        body:
-          properties:
-            clip:
-              type: file
-            enhance:
-              type: boolean
-              docs: |
-                Whether to enhance the clip to improve its quality before cloning. Useful if the clip is low quality.
-      response: EmbeddingResponse


### PR DESCRIPTION
This PR:
- removes the `Clone from clip` docs (for the old `/voices/clone/clip` endpoint)
- Updates the Voice Clone capabilities endpoint
- Adds some header documentation for the unified `/voices/clone` endpoint

This PR is temporary. When #38 is merged, this PR's changes will be overwritten. (But it cannot yet be merged because the new API version is not yet stable.)