### PR TITLE
(chore): uncomment `NPM_TOKEN` in fern to publish alpha

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -20,7 +20,7 @@ groups:
         output:
           location: npm
           package-name: "@cartesia/cartesia-js"
-          # token: ${NPM_TOKEN}
+          token: ${NPM_TOKEN}
         github:
           repository: cartesia-ai/cartesia-js
           mode: push


### PR DESCRIPTION
This PR uncomments the npm token in `gneerators.yml` so that we can publish an alpha version of the JS SDK. 