### PR TITLE
chore: js releases now push directly to main

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -31,8 +31,6 @@ groups:
           token: ${NPM_TOKEN}
         github:
           repository: cartesia-ai/cartesia-js
-          mode: push
-          branch: v2
         config:
           namespaceExport: Cartesia
           allowCustomFetcher: true


### PR DESCRIPTION
This PR updates your JS SDK release process to push directly to main. 