### PR TITLE
fix: js sdk outputs `esm`

### DIFF
--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -32,6 +32,7 @@ groups:
         github:
           repository: cartesia-ai/cartesia-js
         config:
+          outputEsm: true
           namespaceExport: Cartesia
           allowCustomFetcher: true
           skipResponseValidation: true


### PR DESCRIPTION
Because `emittery` is a ESM only dependency, we are going to output ESM by default in the generated SDK