### PR TITLE
Add deprecated models to models.mdx

### DIFF
--- a/fern/build-with-sonic/models.mdx
+++ b/fern/build-with-sonic/models.mdx
@@ -35,6 +35,16 @@ Cartesia provides a family of state-of-the-art models, including our highly-accu
 			<td>October update.</td>
 			<td>en, fr, de, es, pt, zh, ja, hi, it, ko, nl, pl, ru, sv, tr</td>
 		</tr>
+		<tr>
+			<td><pre><code>sonic-english</code></pre></td>
+			<td>[Deprecated] Please use <code>sonic</code> to use the most updated English model or <code>sonic-[date]</code> for a specific model release. <code>sonic-english</code> will forever point to <code>sonic-2024-10-19</code>.</td>
+			<td>en</td>
+		</tr>
+		<tr>
+			<td><pre><code>sonic-multilingual</code></pre></td>
+			<td>[Deprecated] Please use <code>sonic</code> to use the most updated multilingual model or <code>sonic-[date]</code> for a specific model release. <code>sonic-multilingual</code> will forever point to <code>sonic-2024-10-19</code>.</td>
+			<td>en</td>
+		</tr>
 	</table>
 </div>
 


### PR DESCRIPTION
Adding model descriptions to deprecated sonic-english and sonic-multilingual models.

<!-- NB: This repo (cartesia-ai/docs) is public. -->
