### PR TITLE
list<Emotion>

### DIFF
--- a/fern/definition/tts.yml
+++ b/fern/definition/tts.yml
@@ -445,8 +445,6 @@ types:
         name: ANGER_LOWEST
       - value: anger:low
         name: ANGER_LOW
-      - value: anger
-        name: ANGER_NORMAL
       - value: anger:high
         name: ANGER_HIGH
       - value: anger:highest
@@ -455,8 +453,6 @@ types:
         name: POSITIVITY_LOWEST
       - value: positivity:low
         name: POSITIVITY_LOW
-      - value: positivity
-        name: POSITIVITY_NORMAL
       - value: positivity:high
         name: POSITIVITY_HIGH
       - value: positivity:highest
@@ -471,12 +467,8 @@ types:
         name: SADNESS_LOWEST
       - value: sadness:low
         name: SADNESS_LOW
-      - value: sadness
-        name: SADNESS_NORMAL
       - value: curiosity:low
         name: CURIOSITY_LOW
-      - value: curiosity
-        name: CURIOSITY_NORMAL
       - value: curiosity:high
         name: CURIOSITY_HIGH
       - value: curiosity:highest

--- a/fern/definition/tts.yml
+++ b/fern/definition/tts.yml
@@ -410,7 +410,7 @@ types:
   Controls:
     properties:
       speed: Speed
-      emotion: Emotion
+      emotion: list<Emotion>
 
   Speed:
     docs: |


### PR DESCRIPTION
## Description

`__experimental_controls.emotion` should be a list

## Testing

I tested with a local Node package linked to the Fern preview of the SDK change from this.

```js
import { CartesiaClient } from "@cartesia/cartesia-js";

import process from "node:process"
import fs from "node:fs"

// Set up the client.
const client = new CartesiaClient({ apiKey: process.env.CARTESIA_API_KEY });

async function testTTS() {
	let resp = await client.tts.bytes({
			modelId: "sonic-english",
			transcript: "I don't think that's a good idea.",
			voice: {
					mode: "id",
					id: "694f9389-aac1-45b6-b726-9d9369183238",
					__experimental_controls: {
						emotion: ["anger:high"],
					}
			},
			language: "en",
			outputFormat: {
					container: "wav",
					sampleRate: 44100,
					encoding: "pcm_f32le",
			},
	});

	// Write the response to a file.
	fs.writeFileSync("angry.wav", new Uint8Array(resp));

	resp = await client.tts.bytes({
			modelId: "sonic-english",
			transcript: "I don't think that's a good idea.",
			voice: {
					mode: "id",
					id: "694f9389-aac1-45b6-b726-9d9369183238",
					__experimental_controls: {
						emotion: ["sadness:high"],
					}
			},
			language: "en",
			outputFormat: {
					container: "wav",
					sampleRate: 44100,
					encoding: "pcm_f32le",
			},
	});

	// Write the response to a file.
	fs.writeFileSync("sad.wav", new Uint8Array(resp));
}

testTTS();
```