### PR TITLE
demo failing docs: optional files

### DIFF
--- a/fern/definition/infill.yml
+++ b/fern/definition/infill.yml
@@ -1,0 +1,84 @@
+imports:
+  tts: ./tts.yml
+  voice_changer: ./voice-changer.yml
+
+service:
+  base-path: /infill
+  auth: true
+  endpoints:
+    bytes:
+      path: /bytes
+      method: POST
+      display-name: Infill (Bytes)
+      docs: |
+        Generate audio that smoothly connects two existing audio segments. This is useful for inserting new speech between existing speech segments while maintaining natural transitions.
+
+        At least one of `left_audio` or `right_audio` must be provided.
+      request:
+        name: InfillBytesRequest
+        body:
+          properties:
+            left_audio:
+              type: file
+            right_audio:
+              type: file
+            model_id[]:
+              type: string
+              docs: The ID of the model to use for generating audio
+            language[]:
+              type: string
+              docs: The language of the transcript
+            transcript[]:
+              type: string
+              docs: The infill text to generate
+            voice[id]:
+              type: string
+              docs: The ID of the voice to use for generating audio
+            output_format[container]:
+              type: voice_changer.OutputFormatContainer
+              docs: The format of the output audio
+            output_format[sample_rate]:
+              type: integer
+              docs: The sample rate of the output audio
+            output_format[encoding]:
+              type: optional<tts.RawEncoding>
+              docs: |
+                Required for `raw` and `wav` containers.
+            output_format[bit_rate]:
+              type: optional<integer>
+              docs: |
+                Required for `mp3` containers.
+            voice[__experimental_controls][speed]:
+              type: optional<tts.Speed>
+              docs: |
+                Either a number between -1.0 and 1.0 or a natural language description of speed.
+
+                If you specify a number, 0.0 is the default speed, -1.0 is the slowest speed, and 1.0 is the fastest speed.
+            voice[__experimental_controls][emotion][]:
+              type: optional<tts.Emotion>
+              docs: |
+                An array of emotion:level tags.
+
+                Supported emotions are: anger, positivity, surprise, sadness, and curiosity.
+
+                Supported levels are: lowest, low, (omit), high, highest.
+      response: file
+      examples:
+        - name: MP3
+          request:
+            model_id[]: sonic-english
+            language[]: en
+            transcript[]: middle segment
+            voice[id]: 694f9389-aac1-45b6-b726-9d9369183238
+            output_format[container]: mp3
+            output_format[sample_rate]: 44100
+            output_format[bit_rate]: 128000
+        - name: WAV
+          request:
+            model_id[]: sonic-english
+            language[]: en
+            transcript[]: middle segment
+            voice[id]: 694f9389-aac1-45b6-b726-9d9369183238
+            output_format[container]: wav
+            output_format[sample_rate]: 44100
+            output_format[encoding]: pcm_f32le

--- a/fern/generators.yml
+++ b/fern/generators.yml
@@ -4,7 +4,7 @@ groups:
   python-sdk:
     generators:
       - name: fernapi/fern-python-sdk
-        version: 4.2.7
+        version: 4.3.11
         output:
           location: pypi
           package-name: "cartesia"
@@ -40,6 +40,6 @@ groups:
             emittery: "^0.13.1"
             human-id: "^4.1.1"
             ws: "^8.15.13"
-          extraDevDependencies: 
+          extraDevDependencies:
             "@types/ws": "^8.5.13"
         smart-casing: true


### PR DESCRIPTION
NB this is not a real change, just demonstrating some oddness around the Fern type system and multipart form uploads.

In this branch, we have a multipart form upload with multiple files. Marking both files as `optional<file>` makes both of them disappear from the docs and the generated curl example:

<img width="1108" alt="Screenshot 2025-01-21 at 11 33 38 AM" src="https://github.com/user-attachments/assets/a2156c62-b127-493d-b2c8-53de4f2f891d" />
