### PR TITLE
[TTS] Adding missing emotion combinations

### DIFF
--- a/fern/definition/tts.yml
+++ b/fern/definition/tts.yml
@@ -478,6 +478,8 @@ types:
         name: POSITIVITY_HIGHEST
       - value: surprise:lowest
         name: SURPRISE_LOWEST
+      - value: surprise:low
+        name: SURPRISE_LOW
       - value: surprise:high
         name: SURPRISE_HIGH
       - value: surprise:highest
@@ -486,6 +488,12 @@ types:
         name: SADNESS_LOWEST
       - value: sadness:low
         name: SADNESS_LOW
+      - value: sadness:high
+        name: SADNESS_HIGH
+      - value: sadness:highest
+        name: SADNESS_HIGHEST
+      - value: curiosity:lowest
+        name: CURIOSITY_LOWEST
       - value: curiosity:low
         name: CURIOSITY_LOW
       - value: curiosity:high


### PR DESCRIPTION
One of our users reported missing emotions in the JS Client (see comment in [thread](https://discord.com/channels/1159677074307555429/1332897070029475850)). This is a byproduct of missing it in the Fern TTS definitions, fixing that will propagate to the Fern clients.
