### PR TITLE
chore: enable python sdk snippets in docs

### DIFF
--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -142,7 +142,7 @@ navigation:
         paginated: true
         flattened: true
         snippets:
-        #   python: "cartesia"
+          python: "cartesia"
           typescript: "@cartesia/cartesia-js"
         layout:
           - api-status: []


### PR DESCRIPTION
<!-- NB: This repo (cartesia-ai/docs) is public. -->
