### PR TITLE
[Links] Updating some migrated links

### DIFF
--- a/fern/apis/version-2024-06-10/definition/tts.yml
+++ b/fern/apis/version-2024-06-10/definition/tts.yml
@@ -299,7 +299,7 @@ types:
       model_id:
         type: string
         docs: |
-          The ID of the model to use for the generation. See [Models](/build-with-sonic/models) for available models.
+          The ID of the model to use for the generation. See [Models](/build-with-cartesia/models) for available models.
       transcript:
         type: unknown
         docs: |
@@ -356,7 +356,7 @@ types:
       model_id:
         type: string
         docs: |
-          The ID of the model to use for the generation. See [Models](/build-with-sonic/models) for available models.
+          The ID of the model to use for the generation. See [Models](/build-with-cartesia/models) for available models.
       output_format: optional<OutputFormat>
       transcript: optional<string>
       voice: TTSRequestVoiceSpecifier
@@ -373,7 +373,7 @@ types:
       model_id:
         type: string
         docs: |
-          The ID of the model to use for the generation. See [Models](/build-with-sonic/models) for available models.
+          The ID of the model to use for the generation. See [Models](/build-with-cartesia/models) for available models.
       transcript: string
       voice: TTSRequestVoiceSpecifier
       language: optional<SupportedLanguage>

--- a/fern/apis/version-2024-11-13/definition/tts.yml
+++ b/fern/apis/version-2024-11-13/definition/tts.yml
@@ -300,7 +300,7 @@ types:
       model_id:
         type: string
         docs: |
-          The ID of the model to use for the generation. See [Models](/build-with-sonic/models) for available models.
+          The ID of the model to use for the generation. See [Models](/build-with-cartesia/models) for available models.
       transcript:
         type: unknown
         docs: |
@@ -357,7 +357,7 @@ types:
       model_id:
         type: string
         docs: |
-          The ID of the model to use for the generation. See [Models](/build-with-sonic/models) for available models.
+          The ID of the model to use for the generation. See [Models](/build-with-cartesia/models) for available models.
       output_format: optional<OutputFormat>
       transcript: optional<string>
       voice: TTSRequestVoiceSpecifier
@@ -374,7 +374,7 @@ types:
       model_id:
         type: string
         docs: |
-          The ID of the model to use for the generation. See [Models](/build-with-sonic/models) for available models.
+          The ID of the model to use for the generation. See [Models](/build-with-cartesia/models) for available models.
       transcript: string
       voice: TTSRequestVoiceSpecifier
       language: optional<SupportedLanguage>


### PR DESCRIPTION
Some of the links on the TTS Definitions were still `/build-with-sonic/` instead of `/build-with-cartesia/`.