### PR TITLE
Update date in changelog to reflect latest model

### DIFF
--- a/fern/developer-tools/changelog.mdx
+++ b/fern/developer-tools/changelog.mdx
@@ -25,7 +25,7 @@ features could lead to reduced model stability even with that model.
 
 Specific API changes:
 
-- `sonic-2` and `sonic-2-2025-03-07` will ignore experimental controls used with TTS generations
+- `sonic-2` and `sonic-2-2025-04-16` will ignore experimental controls used with TTS generations
 - Voice cloning only supports `similarity` clones -- this technique performs the best across-the-board on the `sonic-2` model.
 - Removed embeddings from all endpoints.
 - Voices may only be specified by Voice ID


### PR DESCRIPTION
<!-- NB: This repo (cartesia-ai/docs) is public. -->
Changelog incorrectly referenced 3/7 as ignoring experimental controls on TTS generations