### PR TITLE
Docs for speed and cloning changes

### DIFF
--- a/fern/apis/version-2024-06-10/definition/tts.yml
+++ b/fern/apis/version-2024-06-10/definition/tts.yml
@@ -215,6 +215,18 @@ types:
 
       This can be used to map chunks of audio to certain transcript submissions.
 
+  ModelSpeed:
+    docs: |
+      > This feature is experimental and may not work for all voices.
+
+      Speed setting for the model. Defaults to `normal`.
+
+      Influences the speed of the generated speech. Faster speeds may reduce hallucination rate.
+    enum:
+      - slow
+      - normal
+      - fast
+
   WebSocketBaseResponse:
     properties:
       context_id: optional<ContextID>
@@ -314,14 +326,7 @@ types:
         docs: |
           The maximum duration of the audio in seconds. You do not usually need to specify this.
           If the duration is not appropriate for the length of the transcript, the output audio may be truncated.
-      text_cfg:
-        type: optional<double>
-        docs: |
-          The text [classifier-free guidance](https://arxiv.org/abs/2207.12598) value for the request.
-
-          Higher values causes the model to attend more to the text but speed up the generation. Lower values reduce the speaking rate but can increase the risk of hallucinations. The default value is `3.0`. For a slower speaking rate, we recommend values between `2.0` and `3.0`. Values are supported between `1.5` and `3.0`.
-
-          This parameter is only supported for `sonic-2` models.
+      speed: optional<ModelSpeed>
       context_id: optional<ContextID>
       continue:
         type: optional<boolean>
@@ -332,9 +337,9 @@ types:
         type: optional<integer>
         docs: |
           The maximum time in milliseconds to buffer text before starting generation. Values between [0, 1000]ms are supported. Defaults to 0 (no buffering).
-          
+
           When set, the model will buffer incoming text chunks until it's confident it has enough context to generate high-quality speech, or the buffer delay elapses, whichever comes first. Without this option set, the model will kick off generations immediately, ceding control of buffering to the user.
-          
+
           Use this to balance responsiveness with higher quality speech generation, which often benefits from having more context.
       flush:
         type: optional<boolean>
@@ -386,7 +391,7 @@ types:
       continue: optional<boolean>
       context_id: optional<string>
       max_buffer_delay_ms: optional<integer>
-      text_cfg: optional<double>
+      speed: optional<ModelSpeed>
 
   TTSRequest:
     properties:
@@ -403,14 +408,7 @@ types:
         docs: |
           The maximum duration of the audio in seconds. You do not usually need to specify this.
           If the duration is not appropriate for the length of the transcript, the output audio may be truncated.
-      text_cfg:
-        type: optional<double>
-        docs: |
-          The text [classifier-free guidance](https://arxiv.org/abs/2207.12598) value for the request.
-
-          Higher values causes the model to attend more to the text but speed up the generation. Lower values reduce the speaking rate but can increase the risk of hallucinations. The default value is `3.0`. For a slower speaking rate, we recommend values between `2.0` and `3.0`. Values are supported between `1.5` and `3.0`.
-
-          This parameter is only supported for `sonic-2` models.
+      speed: optional<ModelSpeed>
 
   SupportedLanguage:
     docs: |

--- a/fern/apis/version-2024-06-10/definition/voices.yml
+++ b/fern/apis/version-2024-06-10/definition/voices.yml
@@ -250,7 +250,7 @@ service:
             enhance:
               type: optional<boolean>
               docs: |
-                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner audio generation at the cost of reduced similarity to the source clip.
+                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner generated speech at the cost of reduced similarity to the source clip.
             base_voice_id:
               type: optional<VoiceId>
               docs: |

--- a/fern/apis/version-2024-06-10/definition/voices.yml
+++ b/fern/apis/version-2024-06-10/definition/voices.yml
@@ -250,11 +250,11 @@ service:
             enhance:
               type: optional<boolean>
               docs: |
-                Whether to enhance the clip to improve its quality before cloning. Useful if the clip has background noise.
-            transcript:
-              type: optional<string>
+                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner audio generation at the cost of reduced similarity to the source clip.
+            base_voice_id:
+              type: optional<VoiceId>
               docs: |
-                Optional transcript of the words spoken in the audio clip. Only used for similarity mode.
+                Optional base voice ID that the cloned voice is derived from.
       response: VoiceMetadata
       examples:
         - name: Stability
@@ -264,7 +264,6 @@ service:
             description: "Copied from Cartesia docs"
             mode: stability
             language: en
-            enhance: true
           response:
             body:
               id: "df076429-66c6-4f3e-b98b-aee4e2c925ab"
@@ -281,8 +280,6 @@ service:
             description: "Copied from Cartesia docs"
             mode: similarity
             language: en
-            transcript: "A transcript of the words spoken in the audio clip."
-            enhance: false
           response:
             body:
               id: "40248dd5-bfe9-48e2-93f7-ea3f9d5c7f72"

--- a/fern/apis/version-2024-11-13/definition/tts.yml
+++ b/fern/apis/version-2024-11-13/definition/tts.yml
@@ -215,6 +215,18 @@ types:
 
       This can be used to map chunks of audio to certain transcript submissions.
 
+  ModelSpeed:
+    docs: |
+      > This feature is experimental and may not work for all voices.
+
+      Speed setting for the model. Defaults to `normal`.
+
+      Influences the speed of the generated speech. Faster speeds may reduce hallucination rate.
+    enum:
+      - slow
+      - normal
+      - fast
+
   WebSocketBaseResponse:
     properties:
       context_id: optional<ContextID>
@@ -315,14 +327,7 @@ types:
         docs: |
           The maximum duration of the audio in seconds. You do not usually need to specify this.
           If the duration is not appropriate for the length of the transcript, the output audio may be truncated.
-      text_cfg:
-        type: optional<double>
-        docs: |
-          The text [classifier-free guidance](https://arxiv.org/abs/2207.12598) value for the request.
-
-          Higher values causes the model to attend more to the text but speed up the generation. Lower values reduce the speaking rate but can increase the risk of hallucinations. The default value is `3.0`. For a slower speaking rate, we recommend values between `2.0` and `3.0`. Values are supported between `1.5` and `3.0`.
-
-          This parameter is only supported for `sonic-2` models.
+      speed: optional<ModelSpeed>
       context_id: optional<ContextID>
       continue:
         type: optional<boolean>
@@ -333,9 +338,9 @@ types:
         type: optional<integer>
         docs: |
           The maximum time in milliseconds to buffer text before starting generation. Values between [0, 1000]ms are supported. Defaults to 0 (no buffering).
-          
+
           When set, the model will buffer incoming text chunks until it's confident it has enough context to generate high-quality speech, or the buffer delay elapses, whichever comes first. Without this option set, the model will kick off generations immediately, ceding control of buffering to the user.
-          
+
           Use this to balance responsiveness with higher quality speech generation, which often benefits from having more context.
       flush:
         type: optional<boolean>
@@ -387,7 +392,7 @@ types:
       continue: optional<boolean>
       context_id: optional<string>
       max_buffer_delay_ms: optional<integer>
-      text_cfg: optional<double>
+      speed: optional<ModelSpeed>
 
   TTSRequest:
     properties:
@@ -404,14 +409,7 @@ types:
         docs: |
           The maximum duration of the audio in seconds. You do not usually need to specify this.
           If the duration is not appropriate for the length of the transcript, the output audio may be truncated.
-      text_cfg:
-        type: optional<double>
-        docs: |
-          The text [classifier-free guidance](https://arxiv.org/abs/2207.12598) value for the request.
-
-          Higher values causes the model to attend more to the text but speed up the generation. Lower values reduce the speaking rate but can increase the risk of hallucinations. The default value is `3.0`. For a slower speaking rate, we recommend values between `2.0` and `3.0`. Values are supported between `1.5` and `3.0`.
-
-          This parameter is only supported for `sonic-2` models.
+      speed: optional<ModelSpeed>
 
   SupportedLanguage:
     docs: |

--- a/fern/apis/version-2024-11-13/definition/voices.yml
+++ b/fern/apis/version-2024-11-13/definition/voices.yml
@@ -313,11 +313,11 @@ service:
             enhance:
               type: optional<boolean>
               docs: |
-                Whether to enhance the clip to improve its quality before cloning. Useful if the clip has background noise.
-            transcript:
-              type: optional<string>
+                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner audio generation at the cost of reduced similarity to the source clip.
+            base_voice_id:
+              type: optional<VoiceId>
               docs: |
-                Optional transcript of the words spoken in the audio clip. Only used for similarity mode.
+                Optional base voice ID that the cloned voice is derived from.
       response: VoiceMetadata
       examples:
         - name: Stability
@@ -327,7 +327,6 @@ service:
             description: "Copied from Cartesia docs"
             mode: stability
             language: en
-            enhance: true
           response:
             body:
               id: "df076429-66c6-4f3e-b98b-aee4e2c925ab"
@@ -344,8 +343,6 @@ service:
             description: "Copied from Cartesia docs"
             mode: similarity
             language: en
-            transcript: "A transcript of the words spoken in the audio clip."
-            enhance: false
           response:
             body:
               id: "40248dd5-bfe9-48e2-93f7-ea3f9d5c7f72"

--- a/fern/apis/version-2024-11-13/definition/voices.yml
+++ b/fern/apis/version-2024-11-13/definition/voices.yml
@@ -313,7 +313,7 @@ service:
             enhance:
               type: optional<boolean>
               docs: |
-                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner audio generation at the cost of reduced similarity to the source clip.
+                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner generated speech at the cost of reduced similarity to the source clip.
             base_voice_id:
               type: optional<VoiceId>
               docs: |

--- a/fern/apis/version-2025-04-16/definition/tts.yml
+++ b/fern/apis/version-2025-04-16/definition/tts.yml
@@ -213,6 +213,18 @@ types:
 
       This can be used to map chunks of audio to certain transcript submissions.
 
+  ModelSpeed:
+    docs: |
+      > This feature is experimental and may not work for all voices.
+
+      Speed setting for the model. Defaults to `normal`.
+
+      Influences the speed of the generated speech. Faster speeds may reduce hallucination rate.
+    enum:
+      - slow
+      - normal
+      - fast
+
   WebSocketBaseResponse:
     properties:
       context_id: optional<ContextID>
@@ -313,14 +325,7 @@ types:
         docs: |
           The maximum duration of the audio in seconds. You do not usually need to specify this.
           If the duration is not appropriate for the length of the transcript, the output audio may be truncated.
-      text_cfg:
-        type: optional<double>
-        docs: |
-          The text [classifier-free guidance](https://arxiv.org/abs/2207.12598) value for the request.
-
-          Higher values causes the model to attend more to the text but speed up the generation. Lower values reduce the speaking rate but can increase the risk of hallucinations. The default value is `3.0`. For a slower speaking rate, we recommend values between `2.0` and `3.0`. Values are supported between `1.5` and `3.0`.
-
-          This parameter is only supported for `sonic-2` models.
+      speed: optional<ModelSpeed>
       context_id: optional<ContextID>
       continue:
         type: optional<boolean>
@@ -331,9 +336,9 @@ types:
         type: optional<integer>
         docs: |
           The maximum time in milliseconds to buffer text before starting generation. Values between [0, 1000]ms are supported. Defaults to 0 (no buffering).
-          
+
           When set, the model will buffer incoming text chunks until it's confident it has enough context to generate high-quality speech, or the buffer delay elapses, whichever comes first. Without this option set, the model will kick off generations immediately, ceding control of buffering to the user.
-          
+
           Use this to balance responsiveness with higher quality speech generation, which often benefits from having more context.
       flush:
         type: optional<boolean>
@@ -385,7 +390,8 @@ types:
       continue: optional<boolean>
       context_id: optional<string>
       max_buffer_delay_ms: optional<integer>
-      text_cfg: optional<double>
+      speed: optional<ModelSpeed>
+
   TTSRequest:
     properties:
       model_id:
@@ -401,14 +407,7 @@ types:
         docs: |
           The maximum duration of the audio in seconds. You do not usually need to specify this.
           If the duration is not appropriate for the length of the transcript, the output audio may be truncated.
-      text_cfg:
-        type: optional<double>
-        docs: |
-          The text [classifier-free guidance](https://arxiv.org/abs/2207.12598) value for the request.
-
-          Higher values causes the model to attend more to the text but speed up the generation. Lower values reduce the speaking rate but can increase the risk of hallucinations. The default value is `3.0`. For a slower speaking rate, we recommend values between `2.0` and `3.0`. Values are supported between `1.5` and `3.0`.
-
-          This parameter is only supported for `sonic-2` models.
+      speed: optional<ModelSpeed>
 
   SupportedLanguage:
     docs: |

--- a/fern/apis/version-2025-04-16/definition/voices.yml
+++ b/fern/apis/version-2025-04-16/definition/voices.yml
@@ -264,13 +264,13 @@ service:
               docs: |
                 The language of the voice.
             enhance:
-              type: boolean
+              type: optional<boolean>
               docs: |
-                Whether to enhance the clip to improve its quality before cloning. Useful if the clip has background noise.
-            transcript:
-              type: optional<string>
+                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner audio generation at the cost of reduced similarity to the source clip.
+            base_voice_id:
+              type: optional<VoiceId>
               docs: |
-                Optional transcript of the words spoken in the audio clip.
+                Optional base voice ID that the cloned voice is derived from.
       response: VoiceMetadata
       examples:
         - name: Similarity
@@ -279,8 +279,6 @@ service:
             name: "A high-similarity cloned voice"
             description: "Copied from Cartesia docs"
             language: en
-            transcript: "A transcript of the words spoken in the audio clip."
-            enhance: false
           response:
             body:
               id: "40248dd5-bfe9-48e2-93f7-ea3f9d5c7f72"

--- a/fern/apis/version-2025-04-16/definition/voices.yml
+++ b/fern/apis/version-2025-04-16/definition/voices.yml
@@ -266,7 +266,7 @@ service:
             enhance:
               type: optional<boolean>
               docs: |
-                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner audio generation at the cost of reduced similarity to the source clip.
+                Whether to apply AI enhancements to the clip to reduce background noise. This leads to cleaner generated speech at the cost of reduced similarity to the source clip.
             base_voice_id:
               type: optional<VoiceId>
               docs: |

--- a/fern/apis/version-2025-04-16/pvc-2025-04-16.mdx
+++ b/fern/apis/version-2025-04-16/pvc-2025-04-16.mdx
@@ -1,5 +1,5 @@
 ---
-title: Pro Voice Cloning (Beta)
+title: Pro Voice Cloning
 subtitle: Learn how to improve voice cloning by leveraging more of your data.
 ---
 


### PR DESCRIPTION
- Replace `text_cfg` with `speed`
- Improve `enhance` docs
- Remove `transcript` in clone
- Add `base_voice_id` to clone