### PR TITLE
Add `sonic-2-2025-05-08`

### DIFF
--- a/fern/build-with-sonic/models.mdx
+++ b/fern/build-with-sonic/models.mdx
@@ -18,7 +18,8 @@ Additional Capabilities:
 
 | Snapshot                                                  | Release Date   | Languages                                                  | Status |
 | --------------------------------------------------------- | -------------- | ---------------------------------------------------------- | ------ |
-| <span style="color: green;">●</span> `sonic-2-2025-04-16` | April 16, 2025 | en, fr, de, es, pt, zh, ja, hi, it, ko, nl, pl, ru, sv, tr | Stable |
+| <span style="color: green;">●</span> `sonic-2-2025-05-08` | May 8, 2025    | en, fr, de, es, pt, zh, ja, hi, it, ko, nl, pl, ru, sv, tr | Stable |
+| `sonic-2-2025-04-16` | April 16, 2025 | en, fr, de, es, pt, zh, ja, hi, it, ko, nl, pl, ru, sv, tr | Stable |
 | `sonic-2-2025-03-07`                                      | March 7, 2025  | en, fr, de, es, pt, zh, ja, hi, it, ko, nl, pl, ru, sv, tr | Stable |
 
 Note: For versions after `sonic-2-2025-03-07`, `_experimental_controls` is not supported.


### PR DESCRIPTION
- This is the new latest stable release that the `sonic-2` alias points to