### PR TITLE
fix: make Voice.is_owner optional in API definition

### DIFF
--- a/fern/apis/version-2025-04-16/definition/voices.yml
+++ b/fern/apis/version-2025-04-16/definition/voices.yml
@@ -16,7 +16,7 @@ types:
     properties:
       id: VoiceId
       is_owner:
-        type: boolean
+        type: optional<boolean>
         docs: |
           Whether the current user is the owner of the voice.
       name: &name


### PR DESCRIPTION
<!-- NB: This repo (cartesia-ai/docs) is public. -->

This fixes a mismatch between the Cartesia API response and the SDK by marking `Voice.is_owner` as optional in the API definition.

## Why

When calling the `update` endpoint, the response doesn't always include `is_owner`, causing the SDK to throw a Pydantic validation error.

## Tests

- Ran `fern generate --api version-2025-04-16 --group python-sdk`
- Verified the Python SDK compiles correctly
- Ran the Python test suite (excluding credential-gated tests)
- Confirmed no regressions in generated types

Fixes https://github.com/cartesia-ai/cartesia-python/issues/35
