### PR TITLE
timestamp_granularities -> timestamp_granularities[]

### DIFF
--- a/fern/apis/version-2024-06-10/definition/stt.yml
+++ b/fern/apis/version-2024-06-10/definition/stt.yml
@@ -141,7 +141,7 @@ service:
                   - `su` (Sundanese)
                   - `yue` (Cantonese)
                 </Accordion>
-            timestamp_granularities:
+            timestamp_granularities[]:
               type: optional<list<TimestampGranularity>>
               docs: |
                 The timestamp granularities to populate for this transcription. Currently only `word` level timestamps are supported.
@@ -177,7 +177,7 @@ service:
           request:
             model: "ink-whisper"
             language: "en"
-            timestamp_granularities: ["word"]
+            timestamp_granularities[]: ["word"]
           response:
             body:
               text: "Hello, this is a test transcription."
@@ -556,7 +556,7 @@ types:
         docs: The duration of the input audio in seconds.
       words:
         type: optional<list<TranscriptionWord>>
-        docs: Word-level timestamps showing the start and end time of each word. Only included when `[word]` is passed into `timestamp_granularities`.
+        docs: Word-level timestamps showing the start and end time of each word. Only included when `[word]` is passed into `timestamp_granularities[]`.
 
   StreamingTranscriptionResponse:
     discriminant: type

--- a/fern/apis/version-2024-11-13/definition/stt.yml
+++ b/fern/apis/version-2024-11-13/definition/stt.yml
@@ -141,7 +141,7 @@ service:
                   - `su` (Sundanese)
                   - `yue` (Cantonese)
                 </Accordion>
-            timestamp_granularities:
+            timestamp_granularities[]:
               type: optional<list<TimestampGranularity>>
               docs: |
                 The timestamp granularities to populate for this transcription. Currently only `word` level timestamps are supported.
@@ -177,7 +177,7 @@ service:
           request:
             model: "ink-whisper"
             language: "en"
-            timestamp_granularities: ["word"]
+            timestamp_granularities[]: ["word"]
           response:
             body:
               text: "Hello, this is a test transcription."
@@ -556,7 +556,7 @@ types:
         docs: The duration of the input audio in seconds.
       words:
         type: optional<list<TranscriptionWord>>
-        docs: Word-level timestamps showing the start and end time of each word. Only included when `[word]` is passed into `timestamp_granularities`.
+        docs: Word-level timestamps showing the start and end time of each word. Only included when `[word]` is passed into `timestamp_granularities[]`.
 
   StreamingTranscriptionResponse:
     discriminant: type

--- a/fern/apis/version-2025-04-16/definition/stt.yml
+++ b/fern/apis/version-2025-04-16/definition/stt.yml
@@ -141,7 +141,7 @@ service:
                   - `su` (Sundanese)
                   - `yue` (Cantonese)
                 </Accordion>
-            timestamp_granularities:
+            timestamp_granularities[]:
               type: optional<list<TimestampGranularity>>
               docs: |
                 The timestamp granularities to populate for this transcription. Currently only `word` level timestamps are supported.
@@ -177,7 +177,7 @@ service:
           request:
             model: "ink-whisper"
             language: "en"
-            timestamp_granularities: ["word"]
+            timestamp_granularities[]: ["word"]
           response:
             body:
               text: "Hello, this is a test transcription."
@@ -556,7 +556,7 @@ types:
         docs: The duration of the input audio in seconds.
       words:
         type: optional<list<TranscriptionWord>>
-        docs: Word-level timestamps showing the start and end time of each word. Only included when `[word]` is passed into `timestamp_granularities`.
+        docs: Word-level timestamps showing the start and end time of each word. Only included when `[word]` is passed into `timestamp_granularities[]`.
 
   StreamingTranscriptionResponse:
     discriminant: type


### PR DESCRIPTION
<!-- NB: This repo (cartesia-ai/docs) is public. -->
 We make this change to match OpenAI's format for timestamp granularities in the API, see https://platform.openai.com/docs/api-reference/audio/createTranscription#audio-createtranscription-timestamp_granularities. 