### PR TITLE
Add formatting instructions for clock time

### DIFF
--- a/fern/build-with-sonic/formatting-text-for-sonic/best-practices.mdx
+++ b/fern/build-with-sonic/formatting-text-for-sonic/best-practices.mdx
@@ -10,6 +10,7 @@ The tips below are specific to current our [Sonic model family](/build-with-cart
 
 1. **Use appropriate punctuation.** Add punctuation where appropriate and at the end of each transcript whenever possible.
 2. **Use dates in MM/DD/YYYY form.** For example, 04/20/2023.
+2. **Add spaces between time and AM/PM.** For example, `7:00 PM`, `7 PM`, `7:00 P.M` instead of `7:00PM`.
 3. **Insert pauses.** To insert pauses, insert "-" or use [break tags](/build-with-cartesia/formatting-text-for-sonic-2/inserting-breaks-pauses) where you need the pause. These tags are considered 1 character and do not need to be separated with adjacent text using a space -- to save credits you can remove spaces around break tags.
 4. **Match the voice to the language.** Each voice has a language that it works best with. You can use the playground to quickly understand which voices are most appropriate for a language.
 5. **Stream in inputs for contiguous audio.** Use [continuations](/build-with-cartesia/capability-guides/stream-inputs-using-continuations) if generating audio that should sound contiguous in separate chunks.

--- a/fern/build-with-sonic/formatting-text-for-sonic/best-practices.mdx
+++ b/fern/build-with-sonic/formatting-text-for-sonic/best-practices.mdx
@@ -9,13 +9,13 @@ The tips below are specific to current our [Sonic model family](/build-with-cart
 </Note>
 
 1. **Use appropriate punctuation.** Add punctuation where appropriate and at the end of each transcript whenever possible.
-2. **Use dates in MM/DD/YYYY form.** For example, 04/20/2023.
-2. **Add spaces between time and AM/PM.** For example, `7:00 PM`, `7 PM`, `7:00 P.M`.
-3. **Insert pauses.** To insert pauses, insert "-" or use [break tags](/build-with-cartesia/formatting-text-for-sonic-2/inserting-breaks-pauses) where you need the pause. These tags are considered 1 character and do not need to be separated with adjacent text using a space -- to save credits you can remove spaces around break tags.
-4. **Match the voice to the language.** Each voice has a language that it works best with. You can use the playground to quickly understand which voices are most appropriate for a language.
-5. **Stream in inputs for contiguous audio.** Use [continuations](/build-with-cartesia/capability-guides/stream-inputs-using-continuations) if generating audio that should sound contiguous in separate chunks.
-6. **Specify [custom pronunciations](/build-with-cartesia/capability-guides/specify-custom-pronunciations) for domain-specific or ambiguous words.** You may want to do this for proper nouns and trademarks, as well as for words that are spelled the same but pronounced differently, like the city of Nice and the adjective "nice."
-7. **Use two question marks to emphasize questions.** For example, "Are you here??" vs. "Are you here?"
-8. **Avoid using quotation marks.** (Unless you intend to refer to a quote.)
-9. **Use a space between a URL or email and a question mark.** Otherwise, the question mark will be read out. For example, write `Did you send the email to support@cartesia.ai ?` instead of `Did you send the email to support@cartesia.ai?`.
-10. **Use "dot" instead of "." in URLs.** For example, write "cartesia dot ai" instead of "cartesia.ai" for better pronunciation.
+1. **Use dates in MM/DD/YYYY form.** For example, 04/20/2023.
+1. **Add spaces between time and AM/PM.** For example, `7:00 PM`, `7 PM`, `7:00 P.M`.
+1. **Insert pauses.** To insert pauses, insert "-" or use [break tags](/build-with-cartesia/formatting-text-for-sonic-2/inserting-breaks-pauses) where you need the pause. These tags are considered 1 character and do not need to be separated with adjacent text using a space -- to save credits you can remove spaces around break tags.
+1. **Match the voice to the language.** Each voice has a language that it works best with. You can use the playground to quickly understand which voices are most appropriate for a language.
+1. **Stream in inputs for contiguous audio.** Use [continuations](/build-with-cartesia/capability-guides/stream-inputs-using-continuations) if generating audio that should sound contiguous in separate chunks.
+1. **Specify [custom pronunciations](/build-with-cartesia/capability-guides/specify-custom-pronunciations) for domain-specific or ambiguous words.** You may want to do this for proper nouns and trademarks, as well as for words that are spelled the same but pronounced differently, like the city of Nice and the adjective "nice."
+1. **Use two question marks to emphasize questions.** For example, "Are you here??" vs. "Are you here?"
+1. **Avoid using quotation marks.** (Unless you intend to refer to a quote.)
+1. **Use a space between a URL or email and a question mark.** Otherwise, the question mark will be read out. For example, write `Did you send the email to support@cartesia.ai ?` instead of `Did you send the email to support@cartesia.ai?`.
+1. **Use "dot" instead of "." in URLs.** For example, write "cartesia dot ai" instead of "cartesia.ai" for better pronunciation.

--- a/fern/build-with-sonic/formatting-text-for-sonic/best-practices.mdx
+++ b/fern/build-with-sonic/formatting-text-for-sonic/best-practices.mdx
@@ -10,7 +10,7 @@ The tips below are specific to current our [Sonic model family](/build-with-cart
 
 1. **Use appropriate punctuation.** Add punctuation where appropriate and at the end of each transcript whenever possible.
 2. **Use dates in MM/DD/YYYY form.** For example, 04/20/2023.
-2. **Add spaces between time and AM/PM.** For example, `7:00 PM`, `7 PM`, `7:00 P.M` instead of `7:00PM`.
+2. **Add spaces between time and AM/PM.** For example, `7:00 PM`, `7 PM`, `7:00 P.M`.
 3. **Insert pauses.** To insert pauses, insert "-" or use [break tags](/build-with-cartesia/formatting-text-for-sonic-2/inserting-breaks-pauses) where you need the pause. These tags are considered 1 character and do not need to be separated with adjacent text using a space -- to save credits you can remove spaces around break tags.
 4. **Match the voice to the language.** Each voice has a language that it works best with. You can use the playground to quickly understand which voices are most appropriate for a language.
 5. **Stream in inputs for contiguous audio.** Use [continuations](/build-with-cartesia/capability-guides/stream-inputs-using-continuations) if generating audio that should sound contiguous in separate chunks.


### PR DESCRIPTION
<!-- NB: This repo (cartesia-ai/docs) is public. -->
- Add docs for formatting instructions based on clock time. Inserted the instructions near the date formatting because both are related to time.

- Renumbered all the numbered items with `1.` because `1.` is a special indicator prefix in markdown. 
  - This allows us to insert items in the middle of a numbered list, instead of just appending, without having to renumber everything

As you can see it still renders properly in the preview:
<img width="723" height="816" alt="image" src="https://github.com/user-attachments/assets/da089f42-33f2-4322-808c-c6269f325ba6" />

 