### PR TITLE
only pre-wrap bash css

### DIFF
--- a/fern/assets/styles.css
+++ b/fern/assets/styles.css
@@ -83,7 +83,7 @@ html {
 	font-weight: normal;
 }
 
-.fern-prose code, .prose-base code {
+.fern-prose .language-bash code, .prose-base .language-bash code {
 	white-space: pre-wrap;
 }
 


### PR DESCRIPTION
Screenshot of this change with bash code on the left and Python code on the right:

<img width="1589" height="711" alt="Screenshot 2025-08-21 at 1 18 23 PM" src="https://github.com/user-attachments/assets/2e1d3e37-ebc3-4ac1-8c8f-095e154222a6" />

Bash code still gets pre-wrapped but Python code gets overflow-scroll.