### PR TITLE
correct expires_in argument

### DIFF
--- a/fern/get-started/authenticate-your-app.mdx
+++ b/fern/get-started/authenticate-your-app.mdx
@@ -69,7 +69,7 @@ await client.auth.accessToken({
     tts: true,
     stt: true
   },
-  expiresIn: 60
+  expires_in: 60
 });
 
 // TTS-only access
@@ -77,7 +77,7 @@ await client.auth.accessToken({
   grants: {
     tts: true
   },
-  expiresIn: 60
+  expires_in: 60
 });
 ````
 </Tab>
@@ -121,7 +121,7 @@ const response = await fetch("https://api.cartesia.ai/access-token", {
   },
   body: JSON.stringify({
     grants: { tts: true, stt: true },
-    expiresIn: 60, // 1 minute
+    expires_in: 60, // 1 minute
   }),
 });
 
@@ -135,7 +135,7 @@ const responseTTS = await fetch("https://api.cartesia.ai/access-token", {
   },
   body: JSON.stringify({
     grants: { tts: true },
-    expiresIn: 60, // 1 minute
+    expires_in: 60, // 1 minute
   }),
 });
 


### PR DESCRIPTION

[PRO-843 Correct 'expiresIn' to 'expires_in' in access token docs](https://linear.app/cartesia/issue/PRO-843/correct-expiresin-to-expires-in-in-access-token-docs)